### PR TITLE
fix: trigger tat-service workflow

### DIFF
--- a/.github/workflows/tat.yml
+++ b/.github/workflows/tat.yml
@@ -4,9 +4,9 @@ on:
     branches: [ main ]
     tags: [ "tat-[0-9]+.[0-9]+.[0-9]+" ]
     paths: [ "**" ]
-  pull_request:
-    branches: [ main ]
-    paths: [ "**" ]
+  # pull_request:
+  #   branches: [ main ]
+  #   paths: [ "**" ]
   workflow_dispatch:
 env:
   REGISTRY: ghcr.io
@@ -63,3 +63,18 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+
+  trigger-tat-service:
+    needs: build-and-push-image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger TAT Service Workflow
+        uses: octokit/request-action@v2.x
+        with:
+          route: POST /repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches
+          owner: Shared-Reality-Lab
+          repo: IMAGE-server
+          workflow_id: tat-service.yml
+          ref: main
+        env:
+          GITHUB_TOKEN: ${{ secrets.WORKFLOW_SECRET }}


### PR DESCRIPTION
Resolves https://github.com/Shared-Reality-Lab/IMAGE-server/issues/1070. This pull request introduces a new job to the `.github/workflows/tat.yml` file to trigger the TAT Service workflow in another repository after the `build-and-push-image` job completes.

Workflow automation:

* [`.github/workflows/tat.yml`](diffhunk://#diff-446efe5e9eb62c1375cc0ede31de37cbfb72f68478e500858623e95c2e9943d5R66-R80): Added a `trigger-tat-service` job that uses `octokit/request-action` to dispatch the `tat-service.yml` workflow in the `IMAGE-server` repository. This job runs on `ubuntu-latest` and requires the `WORKFLOW_SECRET` GitHub token for authentication.## PR description

<!-- Add the description of your PR here -->


## Checklist

Note that we require UI tests to ensure that the added feature will not be
nixed by some future fix and that there is at least some test-as-documentation
to indicate how the fix or enhancement is expected to behave.

- [x] - Added Cypress UI tests
- [x] - Ran `npm test`, ensuring linting passes and that Cypress UI tests keep
        coverage to at least the same percent (reflected in the coverage badge
        that should be updated after the tests run)
- [x] - Added any user documentation. Though not required, this can be a big
        help both for future users and for the PR reviewer.
