### PR TITLE
Revert temporary fixes of PR #18 

### DIFF
--- a/src/editor/extensions/ext-tactile-render/ext-tactile-render.js
+++ b/src/editor/extensions/ext-tactile-render/ext-tactile-render.js
@@ -254,7 +254,7 @@ connectedCallback () {
       }
       svgDoc.querySelector('g[data-image-layer="fullImage"]').remove()
     }
-    svgString = new XMLSerializer().serializeToString(svgDoc).replaceAll('display="inline"', "")
+    svgString = new XMLSerializer().serializeToString(svgDoc)
     
     /*const password = svgEditor.password
 


### PR DESCRIPTION
Revert the temporary fix made to the TAT to avoid changes to the Monarch application. 

Partially addresses Shared-Reality-Lab/IMAGE-Monarch#77.

NOTE: These changes should **NOT** be **pushed to prod** without notifying Monarch users of the updates made to the application as well. 